### PR TITLE
Patch 2

### DIFF
--- a/ml/priority_classification.ipynb
+++ b/ml/priority_classification.ipynb
@@ -1406,7 +1406,7 @@
    "outputs": [],
    "source": [
     "# Check that we have the model files created by the training\n",
-    "!ls -R train/model"
+    "!ls -R {WORKING_FOLDER}/train/model"
    ]
   },
   {
@@ -1444,7 +1444,7 @@
    "outputs": [],
    "source": [
     "# Create our version of the model.\n",
-    "!gcloud ml-engine versions create {model_version} --model {model_name} --origin train/model --staging-bucket {staging_bucket}"
+    "!gcloud ml-engine versions create {model_version} --model {model_name} --origin {WORKING_FOLDER}/train/model --staging-bucket {staging_bucket}"
    ]
   },
   {

--- a/ml/resolution_time_regression.ipynb
+++ b/ml/resolution_time_regression.ipynb
@@ -1488,7 +1488,7 @@
    "outputs": [],
    "source": [
     "# Check that we have the model files created by the training\n",
-    "!ls -R train/model"
+    "!ls -R {WORKING_FOLDER}/train/model"
    ]
   },
   {
@@ -1526,7 +1526,7 @@
    "outputs": [],
    "source": [
     "# Create our version of the model.\n",
-    "!gcloud ml-engine versions create {model_version} --model {model_name} --origin train/model --staging-bucket {staging_bucket}"
+    "!gcloud ml-engine versions create {model_version} --model {model_name} --origin {WORKING_FOLDER}/train/model --staging-bucket {staging_bucket}"
    ]
   },
   {


### PR DESCRIPTION
2 instances of "train/model" path are not recognized when the code is run as-is in datalab, across both priority and resolution_time notebooks. I added a reference to explicitly declare the full path defined earlier in the notebook.